### PR TITLE
remove `page_allocator` and reflector `Version`

### DIFF
--- a/src/alias.zig
+++ b/src/alias.zig
@@ -3,14 +3,16 @@ const builtin = @import("builtin");
 const tools = @import("tools.zig");
 
 pub fn setZigVersion(version: []const u8) !void {
-    const allocator = std.heap.page_allocator;
+    const allocator = tools.getAllocator();
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
     const userHome = tools.getHome();
 
-    const zigPath = try std.fs.path.join(allocator, &[_][]const u8{ userHome, ".zm", "versions", version });
-    defer allocator.free(zigPath);
-
-    const symlinkPath = try std.fs.path.join(allocator, &[_][]const u8{ userHome, ".zm", "current" });
-    defer allocator.free(symlinkPath);
+    const zigPath = try std.fs.path.join(arena_allocator, &[_][]const u8{ userHome, ".zm", "versions", version });
+    const symlinkPath = try std.fs.path.join(arena_allocator, &[_][]const u8{ userHome, ".zm", "current" });
 
     try updateSymlink(zigPath, symlinkPath);
     try verifyZigVersion(allocator, version);

--- a/src/command.zig
+++ b/src/command.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const versions = @import("versions.zig");
 const install = @import("install.zig");
 const alias = @import("alias.zig");
+const tools = @import("tools.zig");
 
 const options = @import("options");
 
@@ -42,10 +43,11 @@ pub fn handleCommands(cmd: Command, params: ?[]const u8) !void {
 }
 
 fn handleList() !void {
-    const allocator = std.heap.page_allocator;
-    const versionsList = try versions.list(allocator);
-    defer versionsList.deinit();
-    for (versionsList.items) |version| {
+    const allocator = tools.getAllocator();
+    var version_list = try versions.VersionList.init(allocator);
+    defer version_list.deinit();
+
+    for (version_list.slice()) |version| {
         std.debug.print("{s}\n", .{version});
     }
 }

--- a/src/download.zig
+++ b/src/download.zig
@@ -148,7 +148,6 @@ fn downloadAndExtract(
     download_node.end();
 
     var extract_node = root_node.start("Extracting", 1);
-    const c_allocator = std.heap.c_allocator;
 
     // ~/.zm/versions/zig-macos-x86_64-0.10.0.tar.xz
     const data_allocator = tools.getAllocator();
@@ -175,12 +174,16 @@ fn downloadAndExtract(
     const downloaded_file = try zvm_dir.openFile(downloaded_file_path, .{});
     defer downloaded_file.close();
 
-    _ = try lib.extract_tarxz_to_dir(c_allocator, zvm_dir_version, downloaded_file);
+    if (builtin.os.tag == .windows) {
+        try lib.extract_zip_dir(zvm_dir_version, downloaded_file);
+    } else {
+        try lib.extract_tarxz_to_dir(allocator, zvm_dir_version, downloaded_file);
+    }
+
     extract_node.end();
 
     var result: [32]u8 = undefined;
     sha256.final(&result);
-    //std.debug.print("Hash computation complete. Hash: {s}\n", .{std.fmt.fmtSliceHexLower(&result)});
     return result;
 }
 

--- a/src/extract.zig
+++ b/src/extract.zig
@@ -3,14 +3,10 @@ const builtin = @import("builtin");
 const tools = @import("tools.zig");
 
 pub fn extract_tarxz_to_dir(allocator: std.mem.Allocator, outDir: std.fs.Dir, file: std.fs.File) !void {
-    if (builtin.os.tag == .windows) {
-        try extract_zip_dir(outDir, file);
-    } else {
-        var buffered_reader = std.io.bufferedReader(file.reader());
-        var decompressed = try std.compress.xz.decompress(allocator, buffered_reader.reader());
-        defer decompressed.deinit();
-        try std.tar.pipeToFileSystem(outDir, decompressed.reader(), .{ .mode_mode = .executable_bit_only, .strip_components = 1 });
-    }
+    var buffered_reader = std.io.bufferedReader(file.reader());
+    var decompressed = try std.compress.xz.decompress(allocator, buffered_reader.reader());
+    defer decompressed.deinit();
+    try std.tar.pipeToFileSystem(outDir, decompressed.reader(), .{ .mode_mode = .executable_bit_only, .strip_components = 1 });
 }
 
 pub fn extract_zip_dir(outDir: std.fs.Dir, file: std.fs.File) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,8 +21,10 @@ pub fn main() !void {
     try tools.dataInit(gpa.allocator());
     defer tools.dataDeinit();
 
-    const args = try std.process.argsAlloc(tools.getAllocator());
-    defer std.process.argsFree(tools.getAllocator(), args);
+    const allocator = tools.getAllocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
 
     const cmd_data = try parseArgs(args);
     try handleCommands(cmd_data.cmd, cmd_data.params);


### PR DESCRIPTION
removed `page_allocator`, and use general purpose allocator

adn reflector the `version`, improved the readability of some codes 

By the way, multiple memory leaks occurred in versions using page_allocator in the past.