### PR TITLE
perf(build): switch build optimization from `ReleaseSafe` to `ReleaseFast`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -76,7 +76,7 @@ pub fn build(b: *Build) void {
             .name = "zvm",
             .root_source_file = b.path("src/main.zig"),
             .target = resolved_target,
-            .optimize = .ReleaseSafe,
+            .optimize = .ReleaseFast,
             .strip = true,
         });
 


### PR DESCRIPTION
This pull request changes the build optimization mode for the Zig Version Manager (zvm) from `ReleaseSafe` to `ReleaseFast`. The `ReleaseFast` mode prioritizes performance by removing safety checks, making it more suitable for production use where maximum efficiency is desired.

### Benchmark Results

Benchmarks were conducted using `hyperfine` to compare the performance of `ReleaseSafe` and `ReleaseFast` builds. Here are the results for various commands:

| Command                  | `ReleaseFast` Time (mean ± σ) | `ReleaseSafe` Time (mean ± σ) | Speed Improvement |
|--------------------------|-------------------------------|-------------------------------|-------------------|
| `zvm --help`             | 4.4 ms ± 2.4 ms              | 4.6 ms ± 1.1 ms              | **1.06× faster**  |
| `zvm -v`                 | 4.6 ms ± 1.1 ms              | 5.1 ms ± 1.0 ms              | **1.11× faster**  |
| `zvm ls`                 | 657.9 ms ± 23.9 ms           | 731.6 ms ± 33.9 ms           | **1.11× faster**  |
| `zvm ls --system`        | 4.6 ms ± 1.0 ms              | 6.3 ms ± 1.1 ms              | **1.35× faster**  |

### Observations
- Across all tested commands, the `ReleaseFast` build consistently outperformed the `ReleaseSafe` build.

### Warnings
- Commands with execution times under 5 ms may have inaccuracies due to shell startup time calibration limitations. These results should still reflect relative performance differences.

## Justification for Change
- Faster command execution aligns with user expectations for a CLI tool.
- The lack of safety checks in `ReleaseFast` is acceptable.

