### PR TITLE
chore: upgrade to Zig 0.14.0 and set minimum build version to 0.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       - name: Build release
         run: zig build release

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.14.0
       - run: zig build test
   lint:
     runs-on: ubuntu-latest

--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 
 const Build = std.Build;
 
-const min_zig_string = "0.13.0";
+const min_zig_string = "0.14.0";
 const semver = std.SemanticVersion{ .major = 0, .minor = 8, .patch = 1 };
 const semver_string = "0.8.1";
 


### PR DESCRIPTION
closes https://github.com/hendriknielaender/zvm/issues/59