### PR TITLE
feat(targets): add support for ARM, PowerPC64LE, LoongArch64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -60,8 +60,12 @@ pub fn build(b: *Build) void {
         .{ .cpu_arch = .x86, .os_tag = .linux },
         .{ .cpu_arch = .x86, .os_tag = .windows },
         .{ .cpu_arch = .aarch64, .os_tag = .linux },
+        .{ .cpu_arch = .aarch64, .os_tag = .windows },
         .{ .cpu_arch = .aarch64, .os_tag = .macos },
         .{ .cpu_arch = .riscv64, .os_tag = .linux },
+        .{ .cpu_arch = .powerpc64le, .os_tag = .linux },
+        .{ .cpu_arch = .arm, .os_tag = .linux },
+        .{ .cpu_arch = .loongarch64, .os_tag = .linux },
     };
 
     for (release_targets) |target_query| {


### PR DESCRIPTION
### Add support for additional CPU architectures and platform combinations

## New architectures:
- ARM (Linux)
- PowerPC64LE (Linux)
- LoongArch64 (Linux)

## New platform combinations:
- AArch64 Windows

These additions will allow zvm to support a wider range of systems, particularly benefiting users on less common architectures and those using ARM-based Windows devices.
