### PR TITLE
fix(shim): make env PATH shims work

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ After installation, configure your shell environment:
 # Get shell-specific configuration
 zvm env
 
-# Example output:
+# Example output on Unix shells:
 # Add this to your ~/.bashrc, ~/.profile, or ~/.zshrc:
-export PATH="/home/user/.local/share/zvm/bin:$PATH"
+export PATH="$HOME/.local/share/.zm/bin:$PATH"
 ```
 
 You can also ask for a specific shell:
@@ -317,11 +317,7 @@ zig build -Doptimize=ReleaseSafe
 ### Common Issues
 
 **PATH not updated after installation**
-```bash
-# Re-run shell configuration
-zvm env
-source ~/.bashrc  # or ~/.zshrc
-```
+- Follow [Setup Your Shell](#setup-your-shell), then restart or reload your shell.
 
 **Version detection not working**
 - Ensure `build.zig.zon` contains `minimum_zig_version` field

--- a/install.ps1
+++ b/install.ps1
@@ -14,12 +14,14 @@ if (-not $useLatest) {
 
 $zvmRepoUrl = "https://github.com/hendriknielaender/zvm"
 $zvmInstallDir = "$HOME\.zm"
+$zvmBinDir = "$zvmInstallDir\bin"
 $architecture = if ([Environment]::Is64BitOperatingSystem) { "x86_64" } else { "x86" }
 $zvmFileName = "$architecture-windows-zvm.zip"
 $zvmExeFileName = "$architecture-windows-zvm.exe"
 $zvmZipPath = "$zvmInstallDir\$zvmFileName"
 $zvmExePath = "$zvmInstallDir\$zvmExeFileName"
-$zvmRenamedExePath = "$zvmInstallDir\zvm.exe"
+$zvmRenamedExePath = "$zvmBinDir\zvm.exe"
+$zvmLegacyExePath = "$zvmInstallDir\zvm.exe"
 
 if ($useLatest) {
     $zvmUrl = "$zvmRepoUrl/releases/latest/download/$zvmFileName"
@@ -30,10 +32,15 @@ if ($useLatest) {
     Write-Output "Installing $versionLabel (rollback/specific version)..."
 }
 
-# Create the installation directory if it doesn't exist
+# Create the installation directories if they don't exist
 if (-not (Test-Path -Path $zvmInstallDir)) {
     Write-Output "Creating installation directory at $zvmInstallDir..."
     New-Item -Path $zvmInstallDir -ItemType Directory | Out-Null
+}
+
+if (-not (Test-Path -Path $zvmBinDir)) {
+    Write-Output "Creating binary directory at $zvmBinDir..."
+    New-Item -Path $zvmBinDir -ItemType Directory | Out-Null
 }
 
 # Download the requested release
@@ -66,10 +73,23 @@ if (Test-Path -Path $zvmRenamedExePath) {
     Write-Output "Removed existing zvm.exe."
 }
 
-# Rename the new executable
+# Move the new executable into bin
 if (Test-Path -Path $zvmExePath) {
-    Rename-Item -Path $zvmExePath -NewName "zvm.exe"
-    Write-Output "Renamed $zvmExeFileName to zvm.exe"
+    Move-Item -Path $zvmExePath -Destination $zvmRenamedExePath
+    Write-Output "Moved $zvmExeFileName to bin\zvm.exe"
+
+    Copy-Item -Path $zvmRenamedExePath -Destination "$zvmBinDir\zig.exe" -Force
+    Copy-Item -Path $zvmRenamedExePath -Destination "$zvmBinDir\zls.exe" -Force
+    Write-Output "Created zig.exe and zls.exe shims."
+
+    if (Test-Path -Path $zvmLegacyExePath) {
+        try {
+            Remove-Item -Path $zvmLegacyExePath -Force
+            Write-Output "Removed legacy zvm.exe from $zvmInstallDir."
+        } catch {
+            Write-Output "Warning: Could not remove legacy $zvmLegacyExePath. Remove it manually if it appears before $zvmBinDir in PATH."
+        }
+    }
 
     try {
         # Set the user environment variable
@@ -77,14 +97,23 @@ if (Test-Path -Path $zvmExePath) {
         [System.Environment]::SetEnvironmentVariable("ZVM_HOME", $zvmInstallDir, [System.EnvironmentVariableTarget]::User)
         Write-Output "ZVM_HOME has been set to $zvmInstallDir for the current user."
 
-        # Add the zvm directory to the user PATH
+        # Add the zvm bin directory to the user PATH
         $currentPath = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
-        if ($currentPath -notlike "*$zvmInstallDir*") {
-            $newPath = "$currentPath;$zvmInstallDir"
+        $pathEntries = if ([string]::IsNullOrEmpty($currentPath)) { @() } else { $currentPath -split ';' }
+        $hasPath = $false
+        foreach ($pathEntry in $pathEntries) {
+            if ($pathEntry.TrimEnd('\') -ieq $zvmBinDir.TrimEnd('\')) {
+                $hasPath = $true
+                break
+            }
+        }
+
+        if (-not $hasPath) {
+            $newPath = if ([string]::IsNullOrEmpty($currentPath)) { $zvmBinDir } else { "$currentPath;$zvmBinDir" }
             [System.Environment]::SetEnvironmentVariable("Path", $newPath, [System.EnvironmentVariableTarget]::User)
-            Write-Output "Added $zvmInstallDir to PATH for the current user."
+            Write-Output "Added $zvmBinDir to PATH for the current user."
         } else {
-            Write-Output "$zvmInstallDir is already in the user PATH."
+            Write-Output "$zvmBinDir is already in the user PATH."
         }
     } catch {
         Write-Output "Error: Unable to set environment variable or update PATH. Please run the script as an administrator."

--- a/src/core/alias.zig
+++ b/src/core/alias.zig
@@ -11,6 +11,7 @@ const context = @import("../Context.zig");
 const validation = @import("../cli/validation.zig");
 const object_pools = @import("../memory.zig");
 const limits = @import("../memory/limits.zig");
+const paths = @import("../platform/paths.zig");
 
 const log = std.log.scoped(.alias);
 
@@ -32,11 +33,8 @@ pub fn set_version(ctx: *context.CliContext, version: []const u8, is_zls: bool) 
     else
         try util_data.get_zvm_zig_version(base_path_buffer);
 
-    var version_path_buffer = try ctx.scratch(.path);
-    defer version_path_buffer.release();
-    const version_path = try version_path_buffer.set(
-        try std.fmt.bufPrint(version_path_buffer.slice(), "{s}/{s}", .{ base_path, version }),
-    );
+    var version_path_storage: [limits.limits.path_length_maximum]u8 = undefined;
+    const version_path = try std.fmt.bufPrint(&version_path_storage, "{s}/{s}", .{ base_path, version });
 
     std.Io.Dir.accessAbsolute(ctx.io, version_path, .{}) catch |err| {
         if (err != error.FileNotFound)
@@ -63,7 +61,7 @@ pub fn set_version(ctx: *context.CliContext, version: []const u8, is_zls: bool) 
         try util_data.get_zvm_current_zig(symlink_path_buffer);
 
     try update_current(ctx.io, version_path, symlink_path);
-    try ensure_unix_shim(ctx, if (is_zls) "zls" else "zig");
+    try ensure_shim(ctx, if (is_zls) "zls" else "zig");
 
     if (is_zls) {
         try verify_zls_version(ctx, version);
@@ -158,22 +156,37 @@ fn update_current(io: std.Io, zig_path: []const u8, symlink_path: []const u8) !v
     try current_dir.symLinkAtomic(io, zig_path, symlink_basename, .{ .is_directory = true });
 }
 
-/// Ensure the Unix shim points at zvm.
-fn ensure_unix_shim(ctx: *context.CliContext, tool_name: []const u8) !void {
+fn ensure_shim(ctx: *context.CliContext, tool_name: []const u8) !void {
     assert(tool_name.len > 0);
-    if (builtin.os.tag == .windows) return;
 
-    var bin_dir_buffer = try ctx.scratch(.path);
-    defer bin_dir_buffer.release();
-    const bin_dir = try util_data.get_zvm_path_segment(bin_dir_buffer, "bin");
+    switch (builtin.os.tag) {
+        // TODO: Add a Windows shim path instead of returning here.
+        .windows => return,
+        .macos => return ensure_shim_with_buffer(ctx, tool_name, 1024),
+        else => return ensure_shim_with_buffer(ctx, tool_name, limits.limits.path_length_maximum),
+    }
+}
+
+// macOS needs at least 1024 here; 512 makes `use <version>` fail with `NameTooLong`.
+fn ensure_shim_with_buffer(
+    ctx: *context.CliContext,
+    tool_name: []const u8,
+    comptime self_path_buffer_len: usize,
+) !void {
+    var zvm_root_storage: [self_path_buffer_len]u8 = undefined;
+    const zvm_root = try paths.get_zvm_root(&zvm_root_storage, ctx.get_home_dir());
+
+    var bin_dir_storage: [self_path_buffer_len]u8 = undefined;
+    const bin_dir = try std.fmt.bufPrint(&bin_dir_storage, "{s}/bin", .{zvm_root});
+
     try util_tool.try_create_path(ctx.io, bin_dir);
 
-    var self_storage: [limits.limits.path_length_maximum]u8 = undefined;
+    var self_storage: [self_path_buffer_len]u8 = undefined;
     const self_len = try std.process.executablePath(ctx.io, &self_storage);
     const self_path = self_storage[0..self_len];
     assert(self_path.len > 0);
 
-    var shim_path_storage: [limits.limits.path_length_maximum]u8 = undefined;
+    var shim_path_storage: [self_path_buffer_len]u8 = undefined;
     const shim_path = try std.fmt.bufPrint(&shim_path_storage, "{s}/{s}", .{ bin_dir, tool_name });
 
     std.Io.Dir.deleteFileAbsolute(ctx.io, shim_path) catch |err| switch (err) {
@@ -184,7 +197,11 @@ fn ensure_unix_shim(ctx: *context.CliContext, tool_name: []const u8) !void {
         },
         else => return err,
     };
-    try std.Io.Dir.symLinkAbsolute(ctx.io, self_path, shim_path, .{});
+
+    var shim_dir = try std.Io.Dir.openDirAbsolute(ctx.io, bin_dir, .{});
+    defer shim_dir.close(ctx.io);
+
+    try shim_dir.symLinkAtomic(ctx.io, self_path, tool_name, .{});
 }
 
 /// Verify the current Zig version.

--- a/src/core/alias.zig
+++ b/src/core/alias.zig
@@ -159,38 +159,26 @@ fn update_current(io: std.Io, zig_path: []const u8, symlink_path: []const u8) !v
 fn ensure_shim(ctx: *context.CliContext, tool_name: []const u8) !void {
     assert(tool_name.len > 0);
 
-    switch (builtin.os.tag) {
-        .macos => return ensure_shim_with_buffer(ctx, tool_name, 1024),
-        else => return ensure_shim_with_buffer(ctx, tool_name, limits.limits.path_length_maximum),
-    }
-}
-
-// macOS needs at least 1024 here; 512 makes `use <version>` fail with `NameTooLong`.
-fn ensure_shim_with_buffer(
-    ctx: *context.CliContext,
-    tool_name: []const u8,
-    comptime self_path_buffer_len: usize,
-) !void {
-    var zvm_root_storage: [self_path_buffer_len]u8 = undefined;
+    var zvm_root_storage: [limits.limits.path_length_maximum]u8 = undefined;
     const zvm_root = try paths.get_zvm_root(&zvm_root_storage, ctx.get_home_dir());
 
-    var bin_dir_storage: [self_path_buffer_len]u8 = undefined;
+    var bin_dir_storage: [limits.limits.path_length_maximum]u8 = undefined;
     const bin_dir = try std.fmt.bufPrint(&bin_dir_storage, "{s}/bin", .{zvm_root});
 
     try util_tool.try_create_path(ctx.io, bin_dir);
 
-    var self_storage: [self_path_buffer_len]u8 = undefined;
+    var self_storage: [limits.limits.path_length_maximum]u8 = undefined;
     const self_len = try std.process.executablePath(ctx.io, &self_storage);
     const self_path = self_storage[0..self_len];
     assert(self_path.len > 0);
 
-    var shim_name_storage: [self_path_buffer_len]u8 = undefined;
+    var shim_name_storage: [limits.limits.path_length_maximum]u8 = undefined;
     const shim_name = if (builtin.os.tag == .windows)
         try std.fmt.bufPrint(shim_name_storage[0 .. tool_name.len + 4], "{s}.exe", .{tool_name})
     else
         tool_name;
 
-    var shim_path_storage: [self_path_buffer_len]u8 = undefined;
+    var shim_path_storage: [limits.limits.path_length_maximum]u8 = undefined;
     const shim_path = try std.fmt.bufPrint(&shim_path_storage, "{s}/{s}", .{ bin_dir, shim_name });
 
     if (builtin.os.tag == .windows and std.ascii.eqlIgnoreCase(self_path, shim_path)) return;

--- a/src/core/alias.zig
+++ b/src/core/alias.zig
@@ -160,8 +160,6 @@ fn ensure_shim(ctx: *context.CliContext, tool_name: []const u8) !void {
     assert(tool_name.len > 0);
 
     switch (builtin.os.tag) {
-        // TODO: Add a Windows shim path instead of returning here.
-        .windows => return,
         .macos => return ensure_shim_with_buffer(ctx, tool_name, 1024),
         else => return ensure_shim_with_buffer(ctx, tool_name, limits.limits.path_length_maximum),
     }
@@ -186,8 +184,16 @@ fn ensure_shim_with_buffer(
     const self_path = self_storage[0..self_len];
     assert(self_path.len > 0);
 
+    var shim_name_storage: [self_path_buffer_len]u8 = undefined;
+    const shim_name = if (builtin.os.tag == .windows)
+        try std.fmt.bufPrint(shim_name_storage[0 .. tool_name.len + 4], "{s}.exe", .{tool_name})
+    else
+        tool_name;
+
     var shim_path_storage: [self_path_buffer_len]u8 = undefined;
-    const shim_path = try std.fmt.bufPrint(&shim_path_storage, "{s}/{s}", .{ bin_dir, tool_name });
+    const shim_path = try std.fmt.bufPrint(&shim_path_storage, "{s}/{s}", .{ bin_dir, shim_name });
+
+    if (builtin.os.tag == .windows and std.ascii.eqlIgnoreCase(self_path, shim_path)) return;
 
     std.Io.Dir.deleteFileAbsolute(ctx.io, shim_path) catch |err| switch (err) {
         error.FileNotFound => {},
@@ -198,10 +204,15 @@ fn ensure_shim_with_buffer(
         else => return err,
     };
 
+    if (builtin.os.tag == .windows) {
+        try std.Io.Dir.copyFileAbsolute(self_path, shim_path, ctx.io, .{});
+        return;
+    }
+
     var shim_dir = try std.Io.Dir.openDirAbsolute(ctx.io, bin_dir, .{});
     defer shim_dir.close(ctx.io);
 
-    try shim_dir.symLinkAtomic(ctx.io, self_path, tool_name, .{});
+    try shim_dir.symLinkAtomic(ctx.io, self_path, shim_name, .{});
 }
 
 /// Verify the current Zig version.

--- a/src/core/alias.zig
+++ b/src/core/alias.zig
@@ -63,6 +63,7 @@ pub fn set_version(ctx: *context.CliContext, version: []const u8, is_zls: bool) 
         try util_data.get_zvm_current_zig(symlink_path_buffer);
 
     try update_current(ctx.io, version_path, symlink_path);
+    try ensure_unix_shim(ctx, if (is_zls) "zls" else "zig");
 
     if (is_zls) {
         try verify_zls_version(ctx, version);
@@ -155,6 +156,35 @@ fn update_current(io: std.Io, zig_path: []const u8, symlink_path: []const u8) !v
     defer current_dir.close(io);
 
     try current_dir.symLinkAtomic(io, zig_path, symlink_basename, .{ .is_directory = true });
+}
+
+/// Ensure the Unix shim points at zvm.
+fn ensure_unix_shim(ctx: *context.CliContext, tool_name: []const u8) !void {
+    assert(tool_name.len > 0);
+    if (builtin.os.tag == .windows) return;
+
+    var bin_dir_buffer = try ctx.scratch(.path);
+    defer bin_dir_buffer.release();
+    const bin_dir = try util_data.get_zvm_path_segment(bin_dir_buffer, "bin");
+    try util_tool.try_create_path(ctx.io, bin_dir);
+
+    var self_storage: [limits.limits.path_length_maximum]u8 = undefined;
+    const self_len = try std.process.executablePath(ctx.io, &self_storage);
+    const self_path = self_storage[0..self_len];
+    assert(self_path.len > 0);
+
+    var shim_path_storage: [limits.limits.path_length_maximum]u8 = undefined;
+    const shim_path = try std.fmt.bufPrint(&shim_path_storage, "{s}/{s}", .{ bin_dir, tool_name });
+
+    std.Io.Dir.deleteFileAbsolute(ctx.io, shim_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        error.IsDir => {
+            log.err("Cannot create shim: {s} is a directory", .{shim_path});
+            return err;
+        },
+        else => return err,
+    };
+    try std.Io.Dir.symLinkAbsolute(ctx.io, self_path, shim_path, .{});
 }
 
 /// Verify the current Zig version.

--- a/src/io/extract.zig
+++ b/src/io/extract.zig
@@ -28,7 +28,7 @@ pub fn extract_static(
 ) !void {
     try signals.check();
     switch (file_type) {
-        .zip => try extract_zip_dir_static(io, extract_op, out_dir, file, root_node),
+        .zip => try extract_zip_dir_static(io, extract_op, out_dir, file, is_zls, root_node),
         .tarxz => try extract_tarxz_to_dir(io, extract_op, out_dir, archive_path, is_zls, root_node),
         .tar_gz => try extract_targz_to_dir(io, out_dir, file, is_zls, root_node),
     }
@@ -131,6 +131,7 @@ fn extract_zip_dir_static(
     extract_op: *object_pools.ExtractOperation,
     out_dir: std.Io.Dir,
     file: std.Io.File,
+    is_zls: bool,
     _: std.Progress.Node,
 ) !void {
     try signals.check();
@@ -157,11 +158,27 @@ fn extract_zip_dir_static(
     const out_path_len = try out_dir.realPath(io, out_path_buffer.slice());
     const out_path = try out_path_buffer.set(out_path_buffer.slice()[0..out_path_len]);
 
-    // Use temporary buffers for copying directories.
+    const copy_source = if (is_zls) tmp_path else try strip_single_dir(io, tmp_dir, tmp_path, extract_op);
+
     // SAFETY: PathBuffer.data is initialized before first use via copy_dir_static
     var source_buffer: object_pools.PathBuffer = .{ .data = undefined, .used = 0 };
-    // SAFETY: PathBuffer.data is initialized before first use via copy_dir_static
     var dest_buffer: object_pools.PathBuffer = .{ .data = undefined, .used = 0 };
-    try tool.copy_dir_static(io, tmp_path, out_path, &source_buffer, &dest_buffer);
+    try tool.copy_dir_static(io, copy_source, out_path, &source_buffer, &dest_buffer);
     try signals.check();
+}
+
+fn strip_single_dir(
+    io: std.Io,
+    tmp_dir: std.Io.Dir,
+    tmp_path: []const u8,
+    extract_op: *object_pools.ExtractOperation,
+) ![]const u8 {
+    var iter = tmp_dir.iterate();
+    const entry = (try iter.next(io)) orelse return error.EmptyArchive;
+    if (entry.kind != .directory) return tmp_path;
+    if (try iter.next(io) != null) return tmp_path;
+
+    const buffer = &extract_op.tmp_path_buffer;
+    const stripped_path = try std.fmt.bufPrint(extract_op.slice(), "{s}/{s}", .{ tmp_path, entry.name });
+    return try buffer.set(stripped_path);
 }

--- a/src/io/extract.zig
+++ b/src/io/extract.zig
@@ -28,7 +28,7 @@ pub fn extract_static(
 ) !void {
     try signals.check();
     switch (file_type) {
-        .zip => try extract_zip_dir_static(io, extract_op, out_dir, file, is_zls, root_node),
+        .zip => try extract_zip_dir_static(io, extract_op, out_dir, file, root_node),
         .tarxz => try extract_tarxz_to_dir(io, extract_op, out_dir, archive_path, is_zls, root_node),
         .tar_gz => try extract_targz_to_dir(io, out_dir, file, is_zls, root_node),
     }
@@ -131,7 +131,6 @@ fn extract_zip_dir_static(
     extract_op: *object_pools.ExtractOperation,
     out_dir: std.Io.Dir,
     file: std.Io.File,
-    is_zls: bool,
     _: std.Progress.Node,
 ) !void {
     try signals.check();
@@ -158,7 +157,8 @@ fn extract_zip_dir_static(
     const out_path_len = try out_dir.realPath(io, out_path_buffer.slice());
     const out_path = try out_path_buffer.set(out_path_buffer.slice()[0..out_path_len]);
 
-    const copy_source = if (is_zls) tmp_path else try strip_single_dir(io, tmp_dir, tmp_path, extract_op);
+    var normalized_source_buffer: object_pools.PathBuffer = .{ .data = undefined, .used = 0 };
+    const copy_source = try normalize_archive_root(io, tmp_dir, tmp_path, &normalized_source_buffer);
 
     // SAFETY: PathBuffer.data is initialized before first use via copy_dir_static
     var source_buffer: object_pools.PathBuffer = .{ .data = undefined, .used = 0 };
@@ -167,18 +167,17 @@ fn extract_zip_dir_static(
     try signals.check();
 }
 
-fn strip_single_dir(
+fn normalize_archive_root(
     io: std.Io,
     tmp_dir: std.Io.Dir,
     tmp_path: []const u8,
-    extract_op: *object_pools.ExtractOperation,
+    buffer: *object_pools.PathBuffer,
 ) ![]const u8 {
     var iter = tmp_dir.iterate();
     const entry = (try iter.next(io)) orelse return error.EmptyArchive;
     if (entry.kind != .directory) return tmp_path;
     if (try iter.next(io) != null) return tmp_path;
 
-    const buffer = &extract_op.tmp_path_buffer;
-    const stripped_path = try std.fmt.bufPrint(extract_op.slice(), "{s}/{s}", .{ tmp_path, entry.name });
-    return try buffer.set(stripped_path);
+    const normalized_path = try std.fmt.bufPrint(buffer.slice(), "{s}/{s}", .{ tmp_path, entry.name });
+    return try buffer.set(normalized_path);
 }

--- a/src/memory/limits.zig
+++ b/src/memory/limits.zig
@@ -47,7 +47,7 @@ pub const limits = struct {
     pub const versions_maximum: u32 = 256; // More than enough for available versions.
 
     /// Maximum length of a file path.
-    pub const path_length_maximum: u32 = 512; // Reasonable path length.
+    pub const path_length_maximum: u32 = std.Io.Dir.max_path_bytes; // Matches Zig fs path limit.
 
     /// Maximum number of path buffers.
     pub const path_buffers_maximum: u32 = 8; // For concurrent path operations.

--- a/src/memory/limits.zig
+++ b/src/memory/limits.zig
@@ -47,7 +47,7 @@ pub const limits = struct {
     pub const versions_maximum: u32 = 256; // More than enough for available versions.
 
     /// Maximum length of a file path.
-    pub const path_length_maximum: u32 = std.Io.Dir.max_path_bytes; // Matches Zig fs path limit.
+    pub const path_length_maximum: u32 = @min(std.Io.Dir.max_path_bytes, 4096);
 
     /// Maximum number of path buffers.
     pub const path_buffers_maximum: u32 = 8; // For concurrent path operations.

--- a/src/shim.zig
+++ b/src/shim.zig
@@ -32,7 +32,23 @@ const AutoInstallError = error{
 var alias_static_buffer: [memory_static.StaticMemory.calculate_memory_size()]u8 align(8) = undefined;
 
 pub fn is_shim_name(program_basename: []const u8) bool {
-    return util_tool.eql_str(program_basename, "zig") or util_tool.eql_str(program_basename, "zls");
+    switch (builtin.os.tag) {
+        .windows => return util_tool.eql_str(program_basename, "zig") or
+            util_tool.eql_str(program_basename, "zig.exe") or
+            util_tool.eql_str(program_basename, "zls") or
+            util_tool.eql_str(program_basename, "zls.exe"),
+        else => return util_tool.eql_str(program_basename, "zig") or
+            util_tool.eql_str(program_basename, "zls"),
+    }
+}
+
+fn exe_name(tool_name: []const u8) []const u8 {
+    assert(util_tool.eql_str(tool_name, "zig") or util_tool.eql_str(tool_name, "zls"));
+
+    switch (builtin.os.tag) {
+        .windows => return if (util_tool.eql_str(tool_name, "zig")) "zig.exe" else "zls.exe",
+        else => return tool_name,
+    }
 }
 
 pub fn run(
@@ -41,6 +57,7 @@ pub fn run(
     remaining_arguments: []const []const u8,
 ) !void {
     assert(is_shim_name(program_name));
+    const tool_name = if (util_tool.eql_str(program_name, "zig") or util_tool.eql_str(program_name, "zig.exe")) "zig" else "zls";
 
     var version_buffer: [memory_limits.limits.version_string_length_maximum]u8 = undefined;
     const version = detect_version.detect_version_for_shim(
@@ -51,12 +68,12 @@ pub fn run(
         error.OutOfMemory => @panic("out of memory in shim version detection"),
         else => {
             log.err("Failed to detect version: {s}", .{@errorName(err)});
-            return run_current(io, program_name, remaining_arguments);
+            return run_current(io, tool_name, remaining_arguments);
         },
     };
 
     if (util_tool.eql_str(version, "current")) {
-        return run_current(io, program_name, remaining_arguments);
+        return run_current(io, tool_name, remaining_arguments);
     }
 
     var adjusted_arguments_buffer: [memory_limits.limits.arguments_maximum][]const u8 = undefined;
@@ -66,19 +83,19 @@ pub fn run(
         &adjusted_arguments_buffer,
     ) catch return error.TooManyArguments;
 
-    if (try run_versioned_if_available(io, program_name, version, adjusted_arguments)) {
+    if (try run_versioned_if_available(io, tool_name, version, adjusted_arguments)) {
         return;
     }
 
-    if (util_tool.eql_str(program_name, "zig")) {
+    if (util_tool.eql_str(tool_name, "zig")) {
         if (auto_install_version_gracefully(io, version)) {
-            if (try run_versioned_if_available(io, program_name, version, adjusted_arguments)) {
+            if (try run_versioned_if_available(io, tool_name, version, adjusted_arguments)) {
                 return;
             }
         }
     }
 
-    return run_current(io, program_name, remaining_arguments);
+    return run_current(io, tool_name, remaining_arguments);
 }
 
 fn run_current(io: std.Io, program_name: []const u8, arguments: []const []const u8) !void {
@@ -198,26 +215,26 @@ fn get_zvm_home_path(buffers: *ShimBuffers, home: []const u8) ![]const u8 {
     return zvm_home;
 }
 
-fn build_tool_path(buffers: *ShimBuffers, program_name: []const u8, zvm_home: []const u8) ![]const u8 {
-    const tool_name = if (util_tool.eql_str(program_name, "zig")) "zig" else "zls";
+fn build_tool_path(buffers: *ShimBuffers, tool_name: []const u8, zvm_home: []const u8) ![]const u8 {
+    const binary_name = exe_name(tool_name);
     return try std.fmt.bufPrint(
         &buffers.tool_path,
         "{s}/current/{s}/{s}",
-        .{ zvm_home, tool_name, tool_name },
+        .{ zvm_home, tool_name, binary_name },
     );
 }
 
 fn build_versioned_tool_path(
     buffers: *ShimBuffers,
-    program_name: []const u8,
+    tool_name: []const u8,
     zvm_home: []const u8,
     version: []const u8,
 ) ![]const u8 {
-    const tool_name = if (util_tool.eql_str(program_name, "zig")) "zig" else "zls";
+    const binary_name = exe_name(tool_name);
     return try std.fmt.bufPrint(
         &buffers.tool_path,
         "{s}/version/{s}/{s}/{s}",
-        .{ zvm_home, tool_name, version, tool_name },
+        .{ zvm_home, tool_name, version, binary_name },
     );
 }
 
@@ -295,13 +312,52 @@ fn build_exec_arguments_slice_windows(
     return argv_list[0..index];
 }
 
+test "shim_names" {
+    try std.testing.expect(is_shim_name("zig"));
+    try std.testing.expect(is_shim_name("zls"));
+    try std.testing.expect(!is_shim_name("zvm"));
+
+    if (builtin.os.tag == .windows) {
+        try std.testing.expect(is_shim_name("zig.exe"));
+        try std.testing.expect(is_shim_name("zls.exe"));
+        try std.testing.expect(!is_shim_name("zvm.exe"));
+    }
+}
+
 test "build_tool_path points at the current tool binary" {
     var buffers: ShimBuffers = undefined;
     buffers.exec_arguments_count = 0;
 
     const zig_path = try build_tool_path(&buffers, "zig", "/tmp/.zm");
-    try std.testing.expectEqualStrings("/tmp/.zm/current/zig/zig", zig_path);
+    const expected_zig = if (builtin.os.tag == .windows)
+        "/tmp/.zm/current/zig/zig.exe"
+    else
+        "/tmp/.zm/current/zig/zig";
+    try std.testing.expectEqualStrings(expected_zig, zig_path);
 
     const zls_path = try build_tool_path(&buffers, "zls", "/tmp/.zm");
-    try std.testing.expectEqualStrings("/tmp/.zm/current/zls/zls", zls_path);
+    const expected_zls = if (builtin.os.tag == .windows)
+        "/tmp/.zm/current/zls/zls.exe"
+    else
+        "/tmp/.zm/current/zls/zls";
+    try std.testing.expectEqualStrings(expected_zls, zls_path);
+}
+
+test "build_versioned_tool_path points at the versioned tool binary" {
+    var buffers: ShimBuffers = undefined;
+    buffers.exec_arguments_count = 0;
+
+    const zig_path = try build_versioned_tool_path(&buffers, "zig", "/tmp/.zm", "0.13.0");
+    const expected_zig = if (builtin.os.tag == .windows)
+        "/tmp/.zm/version/zig/0.13.0/zig.exe"
+    else
+        "/tmp/.zm/version/zig/0.13.0/zig";
+    try std.testing.expectEqualStrings(expected_zig, zig_path);
+
+    const zls_path = try build_versioned_tool_path(&buffers, "zls", "/tmp/.zm", "0.13.0");
+    const expected_zls = if (builtin.os.tag == .windows)
+        "/tmp/.zm/version/zls/0.13.0/zls.exe"
+    else
+        "/tmp/.zm/version/zls/0.13.0/zls";
+    try std.testing.expectEqualStrings(expected_zls, zls_path);
 }

--- a/src/shim.zig
+++ b/src/shim.zig
@@ -8,6 +8,7 @@ const install = @import("core/install.zig");
 const memory_limits = @import("memory/limits.zig");
 const memory_static = @import("memory.zig");
 const paths = @import("platform/paths.zig");
+const util_output = @import("util/output.zig");
 const util_tool = @import("util/tool.zig");
 
 const log = std.log.scoped(.shim);
@@ -140,9 +141,28 @@ fn exec_tool(
     else
         build_exec_arguments_slice(buffers, &argv_list);
 
+    if (builtin.os.tag == .windows) {
+        return exec_tool_windows(io, argv_slice);
+    }
+
     const err = std.process.replace(io, .{ .argv = argv_slice });
     log.err("Failed to execute {s}: {s}", .{ tool_path, @errorName(err) });
     return err;
+}
+
+fn exec_tool_windows(io: std.Io, argv: []const []const u8) !void {
+    var child = try std.process.spawn(io, .{
+        .argv = argv,
+        .expand_arg0 = .no_expand,
+        .stdin = .inherit,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    });
+    const term = try child.wait(io);
+    switch (term) {
+        .exited => |code| std.process.exit(code),
+        else => std.process.exit(@intFromEnum(util_output.ExitCode.invalid_arguments)),
+    }
 }
 
 fn adjust_arguments(

--- a/src/util/tool.zig
+++ b/src/util/tool.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const limits = @import("../memory/limits.zig");
 const object_pools = @import("../memory.zig");
 const assert = std.debug.assert;
 
@@ -84,16 +85,12 @@ pub fn copy_dir_static(
         const entry_name = entry.name;
 
         // Build source sub path.
-        source_path_buffer.reset();
-        const source_sub_path = try source_path_buffer.set(
-            try std.fmt.bufPrint(source_path_buffer.slice(), "{s}/{s}", .{ source_dir, entry_name }),
-        );
+        var source_path_storage: [limits.limits.path_length_maximum]u8 = undefined;
+        const source_sub_path = try std.fmt.bufPrint(&source_path_storage, "{s}/{s}", .{ source_dir, entry_name });
 
         // Build dest sub path.
-        dest_path_buffer.reset();
-        const dest_sub_path = try dest_path_buffer.set(
-            try std.fmt.bufPrint(dest_path_buffer.slice(), "{s}/{s}", .{ dest_dir, entry_name }),
-        );
+        var dest_path_storage: [limits.limits.path_length_maximum]u8 = undefined;
+        const dest_sub_path = try std.fmt.bufPrint(&dest_path_storage, "{s}/{s}", .{ dest_dir, entry_name });
 
         switch (entry.kind) {
             .directory => try copy_dir_static(io, source_sub_path, dest_sub_path, source_path_buffer, dest_path_buffer),

--- a/static/layouts/index.shtml
+++ b/static/layouts/index.shtml
@@ -82,9 +82,9 @@
                 <pre class="code-block"><em># Get shell-specific configuration</em>
 <span>$</span> zvm env
 
-<em># Example output:</em>
+<em># Example output on Unix shells:</em>
 <em># Add this to your ~/.bashrc, ~/.profile, or ~/.zshrc:</em>
-export PATH="/home/user/.local/share/zvm/bin:$PATH"</pre>
+export PATH="$HOME/.local/share/.zm/bin:$PATH"</pre>
               </div>
             </div>
           </section>

--- a/tests/e2e.zig
+++ b/tests/e2e.zig
@@ -633,8 +633,6 @@ fn test_remove_missing(suite: *const Suite, sandbox: []const u8) !void {
 }
 
 fn test_use_creates_shims(suite: *const Suite, sandbox: []const u8) !void {
-    if (builtin.os.tag == .windows) return;
-
     const version = "0.13.0";
     try place_installed_version(suite, sandbox, "zig", version);
     try place_installed_version(suite, sandbox, "zls", version);
@@ -647,17 +645,20 @@ fn test_use_creates_shims(suite: *const Suite, sandbox: []const u8) !void {
     defer zls_outcome.deinit(suite.gpa);
     try assert_exit_zero(zls_outcome, "use ZLS");
 
+    const zig_name = if (builtin.os.tag == .windows) "zig.exe" else "zig";
+    const zls_name = if (builtin.os.tag == .windows) "zls.exe" else "zls";
+
     var zig_path_buffer: [sandbox_path_max]u8 = undefined;
     const zig_path = try std.fmt.bufPrint(
         &zig_path_buffer,
-        "{s}{c}.zm{c}bin{c}zig",
-        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep },
+        "{s}{c}.zm{c}bin{c}{s}",
+        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep, zig_name },
     );
     var zls_path_buffer: [sandbox_path_max]u8 = undefined;
     const zls_path = try std.fmt.bufPrint(
         &zls_path_buffer,
-        "{s}{c}.zm{c}bin{c}zls",
-        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep },
+        "{s}{c}.zm{c}bin{c}{s}",
+        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep, zls_name },
     );
 
     try Io.Dir.cwd().access(suite.process_init.io, zig_path, .{});

--- a/tests/e2e.zig
+++ b/tests/e2e.zig
@@ -311,6 +311,7 @@ fn run_offline_suite(
         .{ .name = "install uses installed Zig before metadata", .run = test_install_uses_local_zig },
         .{ .name = "install uses installed ZLS before metadata", .run = test_install_uses_local_zls },
         .{ .name = "remove non-installed is idempotent", .run = test_remove_missing },
+        .{ .name = "use creates Unix shims", .run = test_use_creates_unix_shims },
         .{ .name = "ZVM_HOME override appears in env", .run = test_zvm_home_override },
         .{ .name = "auto-detect parses build.zig.zon", .run = test_auto_detect_parses_zon },
         .{ .name = "stderr has no ANSI escapes when not a TTY", .run = test_non_tty_stderr_no_ansi },
@@ -629,6 +630,38 @@ fn test_remove_missing(suite: *const Suite, sandbox: []const u8) !void {
     var outcome_again = try run_zvm(suite, sandbox, sandbox, &.{ "remove", "0.0.1" });
     defer outcome_again.deinit(suite.gpa);
     try assert_exit_zero(outcome_again, "remove non-installed (second time)");
+}
+
+fn test_use_creates_unix_shims(suite: *const Suite, sandbox: []const u8) !void {
+    if (builtin.os.tag == .windows) return;
+
+    const version = "0.13.0";
+    try place_installed_version(suite, sandbox, "zig", version);
+    try place_installed_version(suite, sandbox, "zls", version);
+
+    var zig_outcome = try run_zvm(suite, sandbox, sandbox, &.{ "use", version });
+    defer zig_outcome.deinit(suite.gpa);
+    try assert_exit_zero(zig_outcome, "use Zig");
+
+    var zls_outcome = try run_zvm(suite, sandbox, sandbox, &.{ "use", "--zls", version });
+    defer zls_outcome.deinit(suite.gpa);
+    try assert_exit_zero(zls_outcome, "use ZLS");
+
+    var zig_path_buffer: [sandbox_path_max]u8 = undefined;
+    const zig_path = try std.fmt.bufPrint(
+        &zig_path_buffer,
+        "{s}{c}.zm{c}bin{c}zig",
+        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep },
+    );
+    var zls_path_buffer: [sandbox_path_max]u8 = undefined;
+    const zls_path = try std.fmt.bufPrint(
+        &zls_path_buffer,
+        "{s}{c}.zm{c}bin{c}zls",
+        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep },
+    );
+
+    try Io.Dir.cwd().access(suite.process_init.io, zig_path, .{});
+    try Io.Dir.cwd().access(suite.process_init.io, zls_path, .{});
 }
 
 fn test_zvm_home_override(suite: *const Suite, sandbox: []const u8) !void {

--- a/tests/e2e.zig
+++ b/tests/e2e.zig
@@ -311,7 +311,7 @@ fn run_offline_suite(
         .{ .name = "install uses installed Zig before metadata", .run = test_install_uses_local_zig },
         .{ .name = "install uses installed ZLS before metadata", .run = test_install_uses_local_zls },
         .{ .name = "remove non-installed is idempotent", .run = test_remove_missing },
-        .{ .name = "use creates Unix shims", .run = test_use_creates_unix_shims },
+        .{ .name = "use creates shims", .run = test_use_creates_shims },
         .{ .name = "ZVM_HOME override appears in env", .run = test_zvm_home_override },
         .{ .name = "auto-detect parses build.zig.zon", .run = test_auto_detect_parses_zon },
         .{ .name = "stderr has no ANSI escapes when not a TTY", .run = test_non_tty_stderr_no_ansi },
@@ -632,7 +632,7 @@ fn test_remove_missing(suite: *const Suite, sandbox: []const u8) !void {
     try assert_exit_zero(outcome_again, "remove non-installed (second time)");
 }
 
-fn test_use_creates_unix_shims(suite: *const Suite, sandbox: []const u8) !void {
+fn test_use_creates_shims(suite: *const Suite, sandbox: []const u8) !void {
     if (builtin.os.tag == .windows) return;
 
     const version = "0.13.0";
@@ -665,7 +665,6 @@ fn test_use_creates_unix_shims(suite: *const Suite, sandbox: []const u8) !void {
 }
 
 fn test_zvm_home_override(suite: *const Suite, sandbox: []const u8) !void {
-    // env output must reflect the ZVM_HOME we passed in, not any default
     // .zm beneath the developer's real HOME.
     var outcome = try run_zvm(suite, sandbox, sandbox, &.{ "env", "--shell=bash" });
     defer outcome.deinit(suite.gpa);


### PR DESCRIPTION
## Summary

Closes #157.
Closes #158.

This PR makes the `zvm env` setup actually work end to end. After users add the printed `.zm/bin` path to PATH, `zig` and `zls` now have real shims there instead of requiring manual symlinks or copies.

It also updates the README and website examples so they no longer point at the old `zvm/bin` path.

Main changes:

- create `zig` / `zls` shims in `$ZVM_HOME/bin` on Unix
- create `zvm.exe`, `zig.exe`, and `zls.exe` in `%USERPROFILE%\.zm\bin` on Windows
- make the shim dispatch work with Windows `.exe` command names
- keep the installer layout, `zvm env`, and docs aligned around `.zm/bin`
- normalize single-root zip installs so Windows Zig archives end up in the layout the shim expects
- add e2e coverage for shim creation

## Verification

Verified manually on:

- CachyOS
- latest macOS
- Windows 11

Checklist:

- [x] `zig build test`
- [x] `zig build e2e`
- [x] checked `zvm env` output
- [x] checked `zig version` through the shim
- [x] checked `zls --version` through the shim