### PR TITLE
fix: handle removing active versions

### DIFF
--- a/src/core/remove.zig
+++ b/src/core/remove.zig
@@ -35,6 +35,10 @@ pub fn remove(ctx: *context.CliContext, version: []const u8, is_zls: bool, debug
     assert(true_version.len > 0);
     assert(true_version.len <= version.len or is_zls);
 
+    if (!is_zls) {
+        try clear_default_if_active(ctx, true_version);
+    }
+
     // Get current path using path buffer.
     var current_path_buffer = try ctx.scratch(.path);
     defer current_path_buffer.release();
@@ -140,4 +144,31 @@ pub fn remove(ctx: *context.CliContext, version: []const u8, is_zls: bool, debug
             assert(!util_tool.does_path_exist(ctx.io, version_path));
         }
     }
+}
+
+fn clear_default_if_active(ctx: *context.CliContext, version: []const u8) !void {
+    assert(version.len > 0);
+    assert(version.len <= limits.limits.version_string_length_maximum);
+
+    var default_version_buffer: [limits.limits.version_string_length_maximum]u8 = undefined;
+    const default_version = detect_version.find_default_version_in_buffer(
+        ctx,
+        &default_version_buffer,
+    ) catch null;
+
+    const value = default_version orelse return;
+    if (!util_tool.eql_str(value, version)) return;
+
+    var default_version_path_buffer = try ctx.scratch(.path);
+    defer default_version_path_buffer.release();
+
+    const default_version_path = try util_data.get_zvm_path_segment(
+        default_version_path_buffer,
+        "default_version",
+    );
+
+    std.Io.Dir.deleteFileAbsolute(ctx.io, default_version_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
 }

--- a/src/core/remove_installed.zig
+++ b/src/core/remove_installed.zig
@@ -83,7 +83,7 @@ pub fn run(
 
 pub fn progress_items(command: validation.ValidatedCommand.RemoveCommand) u16 {
     _ = command;
-    return 2;
+    return 0;
 }
 
 /// Decide whether removing `version_str` would tear down the active install.

--- a/src/main.zig
+++ b/src/main.zig
@@ -139,11 +139,6 @@ pub fn main(process_init: std.process.Init) !void {
 
     metadata.init_config();
 
-    if (shim.is_shim_name(basename)) {
-        try shim.run(process_init.io, basename, arguments[1..]);
-        unreachable;
-    }
-
     // Inspect environment for color-mode resolution before any output is emitted.
     // Color must be resolved before the first emitter is created so that even
     // error messages during parsing respect the terminal and environment.
@@ -170,6 +165,11 @@ pub fn main(process_init: std.process.Init) !void {
         .color = initial_color,
     };
     try util_output.set_mode(default_output_config);
+
+    if (shim.is_shim_name(basename)) {
+        try shim.run(process_init.io, basename, arguments[1..]);
+        unreachable;
+    }
 
     // Pre-scan for verbose flags so parse-error fatals respect --verbose.
     // Why: parser.parse_command_line emits its own fatals (unknown option,
@@ -225,10 +225,13 @@ pub fn main(process_init: std.process.Init) !void {
     };
     context_instance.assume_yes = parsed_command_line.global_config.assume_yes;
     context_instance.no_input = parsed_command_line.global_config.no_input;
+    const progress_item_count = get_progress_item_count(parsed_command_line.command);
     const root_node = std.Progress.start(process_init.io, .{
         .root_name = "zvm",
-        .estimated_total_items = get_progress_item_count(parsed_command_line.command),
-        .disable_printing = final_output_config.mode != .human_readable or !stderr_is_tty,
+        .estimated_total_items = progress_item_count,
+        .disable_printing = progress_item_count == 0 or
+            final_output_config.mode != .human_readable or
+            !stderr_is_tty,
     });
 
     execute_command(context_instance, parsed_command_line.command, root_node) catch |err| {

--- a/src/platform/signals.zig
+++ b/src/platform/signals.zig
@@ -6,6 +6,7 @@ const exit_code_interrupted = 130;
 
 var interrupt_requested = std.atomic.Value(bool).init(false);
 var cleanup_running = std.atomic.Value(bool).init(false);
+var blocking_wait_running = std.atomic.Value(bool).init(false);
 
 pub fn install_handler() void {
     switch (builtin.os.tag) {
@@ -30,12 +31,23 @@ pub fn end_cleanup() void {
     cleanup_running.store(false, .release);
 }
 
+pub fn begin_blocking_wait() void {
+    blocking_wait_running.store(true, .release);
+    if (requested()) std.process.exit(exit_code_interrupted);
+}
+
+pub fn end_blocking_wait() void {
+    blocking_wait_running.store(false, .release);
+}
+
 fn request_interrupt() void {
-    if (cleanup_running.load(.acquire)) {
+    const already_requested = interrupt_requested.swap(true, .acq_rel);
+    if (already_requested or
+        cleanup_running.load(.acquire) or
+        blocking_wait_running.load(.acquire))
+    {
         std.process.exit(exit_code_interrupted);
     }
-
-    interrupt_requested.store(true, .release);
 }
 
 fn install_handler_posix() void {

--- a/src/shim.zig
+++ b/src/shim.zig
@@ -59,6 +59,7 @@ pub fn run(
 ) !void {
     assert(is_shim_name(program_name));
     const tool_name = if (util_tool.eql_str(program_name, "zig") or util_tool.eql_str(program_name, "zig.exe")) "zig" else "zls";
+    const is_zls = util_tool.eql_str(tool_name, "zls");
 
     var version_buffer: [memory_limits.limits.version_string_length_maximum]u8 = undefined;
     const version = detect_version.detect_version_for_shim(
@@ -69,12 +70,12 @@ pub fn run(
         error.OutOfMemory => @panic("out of memory in shim version detection"),
         else => {
             log.err("Failed to detect version: {s}", .{@errorName(err)});
-            return run_current(io, tool_name, remaining_arguments);
+            return run_current(io, tool_name, is_zls, remaining_arguments);
         },
     };
 
     if (util_tool.eql_str(version, "current")) {
-        return run_current(io, tool_name, remaining_arguments);
+        return run_current(io, tool_name, is_zls, remaining_arguments);
     }
 
     var adjusted_arguments_buffer: [memory_limits.limits.arguments_maximum][]const u8 = undefined;
@@ -88,7 +89,7 @@ pub fn run(
         return;
     }
 
-    if (util_tool.eql_str(tool_name, "zig")) {
+    if (!is_zls) {
         if (auto_install_version_gracefully(io, version)) {
             if (try run_versioned_if_available(io, tool_name, version, adjusted_arguments)) {
                 return;
@@ -96,16 +97,24 @@ pub fn run(
         }
     }
 
-    return run_current(io, tool_name, remaining_arguments);
+    return run_current(io, tool_name, is_zls, remaining_arguments);
 }
 
-fn run_current(io: std.Io, program_name: []const u8, arguments: []const []const u8) !void {
+fn run_current(
+    io: std.Io,
+    program_name: []const u8,
+    is_zls: bool,
+    arguments: []const []const u8,
+) !void {
     var buffers: ShimBuffers = undefined;
     buffers.exec_arguments_count = 0;
 
     const home = try get_home_path(&buffers);
     const zvm_home = try get_zvm_home_path(&buffers, home);
     const tool_path = try build_tool_path(&buffers, program_name, zvm_home);
+    if (!tool_path_exists(io, tool_path)) {
+        report_no_active_version(is_zls);
+    }
     try exec_tool(io, &buffers, tool_path, arguments);
 }
 
@@ -163,6 +172,22 @@ fn exec_tool_windows(io: std.Io, argv: []const []const u8) !void {
         .exited => |code| std.process.exit(code),
         else => std.process.exit(@intFromEnum(util_output.ExitCode.invalid_arguments)),
     }
+}
+
+fn report_no_active_version(is_zls: bool) noreturn {
+    if (!is_zls) {
+        util_output.exit_with(
+            .version_not_found,
+            "No active Zig version selected. Run `zvm use <version>` first.",
+            .{},
+        );
+    }
+
+    util_output.exit_with(
+        .version_not_found,
+        "No active zls version selected. Run `zvm use --zls <version>` first.",
+        .{},
+    );
 }
 
 fn adjust_arguments(

--- a/src/util/confirm.zig
+++ b/src/util/confirm.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
+const signals = @import("../platform/signals.zig");
 
 const max_prompt_length_bytes = 256;
 const max_response_length_bytes = 32;
@@ -94,13 +95,13 @@ pub fn confirm_destructive(
     var read_buffer: [max_response_length_bytes]u8 = undefined;
     var stdin_reader = std.Io.File.stdin().reader(io, &read_buffer);
 
-    var line_buffer: [max_response_length_bytes]u8 = undefined;
-    const bytes_read = stdin_reader.interface.readSliceShort(&line_buffer) catch
+    signals.begin_blocking_wait();
+    defer signals.end_blocking_wait();
+    const line = stdin_reader.interface.takeDelimiter('\n') catch
         return error.StdinReadFailed;
-    if (bytes_read == 0) return !default_no == false; // EOF on TTY: treat as no.
+    if (line == null) return !default_no == false; // EOF on TTY: treat as no.
 
-    const newline_index = std.mem.indexOfScalar(u8, line_buffer[0..bytes_read], '\n') orelse bytes_read;
-    const response = std.mem.trim(u8, line_buffer[0..newline_index], " \t\r");
+    const response = std.mem.trim(u8, line.?, " \t\r");
 
     return interpret_response(response, default_no);
 }

--- a/tests/e2e.zig
+++ b/tests/e2e.zig
@@ -311,6 +311,8 @@ fn run_offline_suite(
         .{ .name = "install uses installed Zig before metadata", .run = test_install_uses_local_zig },
         .{ .name = "install uses installed ZLS before metadata", .run = test_install_uses_local_zls },
         .{ .name = "remove non-installed is idempotent", .run = test_remove_missing },
+        .{ .name = "remove active Zig", .run = test_remove_active_zig },
+        .{ .name = "remove active ZLS", .run = test_remove_active_zls },
         .{ .name = "use creates shims", .run = test_use_creates_shims },
         .{ .name = "ZVM_HOME override appears in env", .run = test_zvm_home_override },
         .{ .name = "auto-detect parses build.zig.zon", .run = test_auto_detect_parses_zon },
@@ -421,6 +423,34 @@ fn assert_not_contains(haystack: []const u8, needle: []const u8, label: []const 
         );
         return error.ForbiddenContent;
     }
+}
+
+fn assert_path_exists(suite: *const Suite, path: []const u8, label: []const u8) !void {
+    assert(path.len > 0);
+    Io.Dir.cwd().access(suite.process_init.io, path, .{}) catch |err| {
+        std.debug.print(
+            "    {s}: expected path to exist: {s} ({s})\n",
+            .{ label, path, @errorName(err) },
+        );
+        return error.PathMissing;
+    };
+}
+
+fn assert_path_missing(suite: *const Suite, path: []const u8, label: []const u8) !void {
+    assert(path.len > 0);
+    Io.Dir.cwd().access(suite.process_init.io, path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => {
+            std.debug.print(
+                "    {s}: failed to stat path {s}: {s}\n",
+                .{ label, path, @errorName(err) },
+            );
+            return err;
+        },
+    };
+
+    std.debug.print("    {s}: expected path to be missing: {s}\n", .{ label, path });
+    return error.PathStillExists;
 }
 
 fn assert_env_config_dir(stdout: []const u8, sandbox: []const u8, label: []const u8) !void {
@@ -630,6 +660,125 @@ fn test_remove_missing(suite: *const Suite, sandbox: []const u8) !void {
     var outcome_again = try run_zvm(suite, sandbox, sandbox, &.{ "remove", "0.0.1" });
     defer outcome_again.deinit(suite.gpa);
     try assert_exit_zero(outcome_again, "remove non-installed (second time)");
+}
+
+fn test_remove_active_zig(suite: *const Suite, sandbox: []const u8) !void {
+    const version = "0.13.0";
+    try place_installed_version(suite, sandbox, "zig", version);
+
+    var use_outcome = try run_zvm(suite, sandbox, sandbox, &.{ "use", version });
+    defer use_outcome.deinit(suite.gpa);
+    try assert_exit_zero(use_outcome, "use Zig before remove");
+
+    var remove_outcome = try run_zvm(suite, sandbox, sandbox, &.{ "--yes", "remove", version });
+    defer remove_outcome.deinit(suite.gpa);
+    try assert_exit_zero(remove_outcome, "remove active Zig");
+
+    var version_path_buffer: [sandbox_path_max]u8 = undefined;
+    const version_path = try std.fmt.bufPrint(
+        &version_path_buffer,
+        "{s}{c}.zm{c}version{c}zig{c}{s}",
+        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep, version },
+    );
+    var current_path_buffer: [sandbox_path_max]u8 = undefined;
+    const current_path = try std.fmt.bufPrint(
+        &current_path_buffer,
+        "{s}{c}.zm{c}current{c}zig",
+        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep },
+    );
+    var default_path_buffer: [sandbox_path_max]u8 = undefined;
+    const default_path = try std.fmt.bufPrint(
+        &default_path_buffer,
+        "{s}{c}.zm{c}default_version",
+        .{ sandbox, std.fs.path.sep, std.fs.path.sep },
+    );
+    const zig_name = if (builtin.os.tag == .windows) "zig.exe" else "zig";
+    var shim_path_buffer: [sandbox_path_max]u8 = undefined;
+    const shim_path = try std.fmt.bufPrint(
+        &shim_path_buffer,
+        "{s}{c}.zm{c}bin{c}{s}",
+        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep, zig_name },
+    );
+
+    try assert_path_missing(suite, version_path, "active version dir");
+    try assert_path_missing(suite, current_path, "active current link");
+    try assert_path_missing(suite, default_path, "active default version");
+    try assert_path_exists(suite, shim_path, "active shim");
+
+    var argv = [_][]const u8{ shim_path, "version" };
+    var env_map = try clone_parent_env(suite);
+    defer env_map.deinit();
+    try apply_sandbox_overrides(&env_map, sandbox);
+
+    const result = try std.process.run(suite.gpa, suite.process_init.io, .{
+        .argv = &argv,
+        .environ_map = &env_map,
+        .cwd = .{ .path = sandbox },
+        .stdout_limit = .limited(stdio_limit_bytes),
+        .stderr_limit = .limited(stdio_limit_bytes),
+    });
+    defer suite.gpa.free(result.stdout);
+    defer suite.gpa.free(result.stderr);
+
+    const exit_code: u8 = switch (result.term) {
+        .exited => |code| code,
+        else => 255,
+    };
+    if (exit_code == 0) {
+        std.debug.print("    shim after active remove unexpectedly exited 0\n", .{});
+        return error.UnexpectedZeroExit;
+    }
+    try assert_contains(result.stderr, "No active Zig version selected", "no active shim");
+    try assert_not_contains(result.stderr, "FileNotFound", "no active shim");
+}
+
+fn test_remove_active_zls(suite: *const Suite, sandbox: []const u8) !void {
+    const version = "0.13.0";
+    try place_installed_version(suite, sandbox, "zls", version);
+
+    var use_outcome = try run_zvm(suite, sandbox, sandbox, &.{ "use", "--zls", version });
+    defer use_outcome.deinit(suite.gpa);
+    try assert_exit_zero(use_outcome, "use ZLS before remove");
+
+    var remove_outcome = try run_zvm(suite, sandbox, sandbox, &.{ "--yes", "remove", "--zls", version });
+    defer remove_outcome.deinit(suite.gpa);
+    try assert_exit_zero(remove_outcome, "remove active ZLS");
+
+    const zls_name = if (builtin.os.tag == .windows) "zls.exe" else "zls";
+    var shim_path_buffer: [sandbox_path_max]u8 = undefined;
+    const shim_path = try std.fmt.bufPrint(
+        &shim_path_buffer,
+        "{s}{c}.zm{c}bin{c}{s}",
+        .{ sandbox, std.fs.path.sep, std.fs.path.sep, std.fs.path.sep, zls_name },
+    );
+    try assert_path_exists(suite, shim_path, "active ZLS shim");
+
+    var argv = [_][]const u8{ shim_path, "version" };
+    var env_map = try clone_parent_env(suite);
+    defer env_map.deinit();
+    try apply_sandbox_overrides(&env_map, sandbox);
+
+    const result = try std.process.run(suite.gpa, suite.process_init.io, .{
+        .argv = &argv,
+        .environ_map = &env_map,
+        .cwd = .{ .path = sandbox },
+        .stdout_limit = .limited(stdio_limit_bytes),
+        .stderr_limit = .limited(stdio_limit_bytes),
+    });
+    defer suite.gpa.free(result.stdout);
+    defer suite.gpa.free(result.stderr);
+
+    const exit_code: u8 = switch (result.term) {
+        .exited => |code| code,
+        else => 255,
+    };
+    if (exit_code == 0) {
+        std.debug.print("    shim after active remove unexpectedly exited 0\n", .{});
+        return error.UnexpectedZeroExit;
+    }
+    try assert_contains(result.stderr, "No active zls version selected", "no active shim");
+    try assert_contains(result.stderr, "zvm use --zls <version>", "no active shim");
+    try assert_not_contains(result.stderr, "FileNotFound", "no active shim");
 }
 
 fn test_use_creates_shims(suite: *const Suite, sandbox: []const u8) !void {


### PR DESCRIPTION
## Summary

Closes #162.

This PR fixes the case where removing the currently active Zig/ZLS version looks like it hangs.

The confirmation prompt now shows normally, `y` continues immediately, and `Ctrl+C` exits while waiting for input.

After removing the active version, zvm leaves that tool with no active version selected. The shim stays in place and prints a clear error if there is no active version.

Main changes:

- disable progress rendering for `remove`
- make confirmation prompts read one line instead of waiting for the whole fixed buffer
- make blocking prompts exit on `Ctrl+C`
- clear Zig `default_version` when the removed active Zig version matches it
- keep `zig` / `zls` shims after removing the active version
- show a clear no-active-version message from the shim
- add e2e coverage for removing active Zig and ZLS versions

## Verification

<p align="center">
  <img height="360" alt="picture" src="https://github.com/user-attachments/assets/3b2fed7d-8a62-4b11-a0dc-b4e8ed1f22ce" />&nbsp;<img height="360" alt="picture" src="https://github.com/user-attachments/assets/ffee3453-7bf9-4261-ae6b-fc09b2aa19fd" />
</p>